### PR TITLE
ci: make Styio Preview fuzz workflow manual-only

### DIFF
--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -1,8 +1,6 @@
 name: styio-nightly-fuzz
 
 on:
-  schedule:
-    - cron: "0 3 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- remove the redundant daily fuzz schedule
- retain workflow_dispatch for intentional manual runs
- preserve every fuzz job and command unchanged

## Validation
- trigger-only body equivalence check passed
- git diff --check passed
- no workflow was dispatched